### PR TITLE
SSH-able Docker Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ For more information, read [Putting Docker Compose on top of
 BOSH (or: I May Never Write Another BOSH Release Again)][1].
 
 [1]: https://jameshunt.us/writings/docker-compose-on-bosh.html
+
+
+## The Jumpbox Option
+
+This release also contains a peculiar little job called `jumpbox`,
+that allows you to colocate users with SSH keys, who will then be
+placed inside of a container image of their choosing when they log
+in.  See [manifests/jumpbox.yml](manifests/jumpbox.yml) for a
+complete example.

--- a/jobs/docker/monit
+++ b/jobs/docker/monit
@@ -4,8 +4,10 @@ check process docker
   stop  program "/var/vcap/jobs/docker/bin/docker stop"
   group vcap
 
+<% if !p('recipe', {}).empty? %>
 check process compose
   with pidfile /var/vcap/sys/run/docker/compose.pid
   start program "/var/vcap/jobs/docker/bin/compose start"
   stop  program "/var/vcap/jobs/docker/bin/compose stop"
   group vcap
+<% end %>

--- a/jobs/docker/templates/etc/running/docker-compose.yml
+++ b/jobs/docker/templates/etc/running/docker-compose.yml
@@ -1,1 +1,1 @@
-<%= p('recipe').to_yaml.to_s %>
+<%= p('recipe', {}).to_yaml.to_s %>

--- a/jobs/jumpbox/spec
+++ b/jobs/jumpbox/spec
@@ -1,0 +1,66 @@
+---
+name: jumpbox
+description: |
+  This job allows you to colocate local users who are immediately
+  dumped into a container running an image of their choice, with
+  their persistent home directories mounted.
+
+  This enables a jumpbox-like experience, without needing constant
+  redeploys to pick up new tools, updates, and environmental
+  customizations.
+
+templates:
+  bin/pre-start: bin/pre-start
+  bin/shell:     bin/shell
+
+properties:
+  users:
+    description: |
+      A list of local users, their SSH keys, and prefered images.
+      To specify more than one authorized key in the `key` property,
+      just make it a newline string, or a list.
+
+      The full list of supported keys (per user entry) is:
+
+        username       (required) The username for this user.
+
+        key            (required) The SSH authorized key for this user.
+
+        image                     The Docker image to spin up for this
+                                  user when they log in successfully.
+
+        home                      The path (in the container) to mount
+                                  this users home directory into.
+
+    example: |
+      users:
+        - username: jhunt
+          image:    'huntprod/jumpbox:jhunt'
+          key:       ssh-ed25519 AAAAC3NzaC1...JvthCmK jhunt@laptop
+
+  default.image:
+    default:     'huntprod/cf-jumpbox:latest'
+    description: |
+      The default image to use for users who do not have one listed
+      explicitly.  The Dockerfile for the _default_ default image
+      can be found in the `docker-boshrelease` GitHub repository,
+      under `jumpbox/`.
+
+  default.home:
+    default:     /home/(username)
+    description: |
+      The default path (in the container) where the users persistent
+      home directory will be mounted.  The string `(username)` will
+      be replaced by the actual username for the account.
+
+  homes:
+    default: /var/vcap/store/jumpbox/home
+    description: |
+      Where to store user home directories on the jumpbox/docker VM.
+      Each user gets a directory underneath this path, which gets
+      mounted into their container image every time they log in.
+
+      By default, these home directories are stored on persistent disk;
+      but if you need to move it, you can.  Note that BOSH will always
+      have a `store` directory, even if you don't provision a persistent
+      disk to mount it on.

--- a/jobs/jumpbox/templates/bin/pre-start
+++ b/jobs/jumpbox/templates/bin/pre-start
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -eu
+
+HOMES="<%= p('homes') %>"
+mkdir -p $HOMES
+
+<% p('users').each do |user|
+
+  username = user['username'] || ''
+  image    = user['image']    || p('default.image')
+  home     = user['home']     || p('default.home')
+
+  if username.empty?
+    raise "The 'username' field of each user entry is *required*."
+  end
+
+  if user['key'] && user['keys']
+    raise "User '#{username}' has both 'key' and 'keys' specified; choose one."
+  end
+
+  keys = user['key'] || user['keys'] || ''
+  if keys.empty?
+    raise "User '#{username}' has no SSH authorized keys specified."
+  end
+
+  if image.empty?
+    raise "User '#{username}' has no image specified, and default.image is not set."
+  end
+  if home.empty?
+    raise "User '#{username}' has no home directory specified, and default.home is not set."
+  end
+%>
+echo "[$(date)] pre-start/$$: setting up <%= username %>..."
+getent passwd <%= username %> > /dev/null || useradd --create-home <%= username %> --base-dir $HOMES
+passwd -d <%= username %>
+usermod -s /var/vcap/jobs/jumpbox/bin/shell <%= username %>
+usermod -G vcap,bosh_sshers <%= username %>
+
+chmod 0700 ~<%= username %>
+mkdir -p ~<%= username %>/.ssh
+touch ~<%= username %>/.ssh/authorized_keys
+chmod 0600 ~<%= username %>/.ssh/authorized_keys
+cat > ~<%= username %>/.ssh/authorized_keys <<EOF
+<%= [keys].flatten.join("\n") %>
+EOF
+chown -R <%= username %>: $HOMES/<%= username %>
+
+<% end %>

--- a/jobs/jumpbox/templates/bin/shell
+++ b/jobs/jumpbox/templates/bin/shell
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+export PATH="$PATH:/var/vcap/packages/docker/bin"
+export DOCKER_HOST='unix:///var/vcap/sys/run/docker/docker.sock'
+
+HOMES="<%= p('homes') %>"
+case $USER in
+<% p('users').each do |user| %>
+<%= user['username'] %>)
+  docker pull "<%= user['image'] || p('default.image') %>"
+  exec docker run -it --rm -v $HOMES/$USER:<%= user['home'] || p('default.home') %> "<%= user['image'] || p('default.image') %>"
+  exit 1
+  ;;
+<% end %>
+
+*)
+  echo >&2 "session denied by jumpbox configuration."
+  exit 1;
+esac

--- a/jumpbox/Dockerfile
+++ b/jumpbox/Dockerfile
@@ -1,0 +1,104 @@
+FROM ubuntu:18.04
+MAINTAINER James Hunt <james@niftylogic.com>
+
+ARG bbr_version=1.5.1
+ARG bosh_version=6.0.0
+ARG cf_version=6.46.0
+ARG credhub_version=2.5.2
+ARG fly_version=5.4.1
+ARG genesis_version=2.6.17
+ARG jq_version=1.6
+ARG kubectl_version=1.15.2
+ARG safe_version=1.3.0
+ARG spruce_version=1.22.0
+ARG terraform_version=0.12.6
+ARG vault_version=1.2.1
+
+RUN apt-get update \
+ && apt-get install -y \
+      curl wget \
+      git \
+      tmux tmate screen \
+      tree file \
+      vim \
+      bzip2 zip unzip \
+      lsof \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ \
+ && echo "Installing 'bbr' v${bbr_version}" \
+ &&   curl -sLo /usr/bin/bbr https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/download/v${bbr_version}/bbr-${bbr_version}-linux-amd64 \
+ &&   chmod 0755 /usr/bin/bbr \
+ &&   /usr/bin/bbr -v \
+ \
+ && echo "Installing 'bosh' v${bosh_version}" \
+ &&   curl -sLo /usr/bin/bosh https://github.com/cloudfoundry/bosh-cli/releases/download/v${bosh_version}/bosh-cli-${bosh_version}-linux-amd64 \
+ &&   chmod 0755 /usr/bin/bosh \
+ &&   /usr/bin/bosh -v \
+ \
+ && echo "Installing 'cf' v${cf_version}" \
+ &&   curl -sLo cf.tar.gz "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${cf_version}" \
+ &&   tar -xzf cf.tar.gz \
+ &&   mv cf /usr/bin/cf \
+ &&   chmod 0755 ./usr/bin/cf \
+ &&   rm -f cf.tar.gz \
+ &&   /usr/bin/cf --version \
+ \
+ && echo "Installing 'credhub' v${credhub_version}" \
+ &&   curl -sLo credhub.tar.gz https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${credhub_version}/credhub-linux-${credhub_version}.tgz \
+ &&   tar -xzf credhub.tar.gz \
+ &&   mv credhub /usr/bin/credhub \
+ &&   chmod 0755 /usr/bin/credhub \
+ &&   rm -f credhub.tar.gz \
+ &&   /usr/bin/credhub --version \
+ \
+ && echo "Installing 'fly v${fly_version}'" \
+ &&   curl -sLo fly.tar.gz https://github.com/concourse/concourse/releases/download/v${fly_version}/fly-${fly_version}-linux-amd64.tgz \
+ &&   tar -xzf fly.tar.gz \
+ &&   mv fly /usr/bin/fly \
+ &&   chmod 0755 /usr/bin/fly \
+ &&   rm -f fly.tar.gz \
+ &&   /usr/bin/fly -v \
+ \
+ && echo "Installing 'genesis' ${genesis_version}" \
+ &&   curl -sLo /usr/bin/genesis https://github.com/genesis-community/genesis/releases/download/v${genesis_version}/genesis \
+ &&   chmod 0755 /usr/bin/genesis \
+ &&   /usr/bin/genesis -v \
+ \
+ && echo "Installing 'jq' ${jq_version}" \
+ &&   curl -sLo /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-${jq_version}/jq-linux64 \
+ &&   chmod 0755 /usr/bin/jq \
+ &&   /usr/bin/jq --version \
+ \
+ && echo "Installing 'kubectl' v${kubectl_version}" \
+ &&   curl -sLo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl \
+ &&   chmod 0755 /usr/bin/kubectl \
+ &&   /usr/bin/kubectl version --client \
+ \
+ && echo "Installing 'safe' v${safe_version}" \
+ &&   curl -sLo /usr/bin/safe https://github.com/starkandwayne/safe/releases/download/v${safe_version}/safe-linux-amd64 \
+ &&   chmod 0755 /usr/bin/safe \
+ &&   /usr/bin/safe -v \
+ \
+ && echo "Installing 'spruce' v${spruce_version}" \
+ &&   curl -sLo /usr/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${spruce_version}/spruce-linux-amd64 \
+ &&   chmod 0755 /usr/bin/spruce \
+ &&   /usr/bin/spruce -v \
+ \
+ && echo "Installing 'terraform' v${terraform_version}" \
+ &&   curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip \
+ &&   unzip -q terraform.zip \
+ &&   mv terraform /usr/bin/terraform \
+ &&   chmod 0755 /usr/bin/terraform \
+ &&   rm terraform.zip \
+ &&   /usr/bin/terraform -v \
+ \
+ && echo "Installing 'vault' v${vault_version}" \
+ &&   curl -sLo vault.zip https://releases.hashicorp.com/vault/${vault_version}/vault_${vault_version}_linux_amd64.zip \
+ &&   unzip -q vault.zip \
+ &&   mv vault /usr/bin/vault \
+ &&   chmod 0755 /usr/bin/vault \
+ &&   rm vault.zip \
+ &&   /usr/bin/vault -v \
+ \
+ && echo "DONE"

--- a/jumpbox/Makefile
+++ b/jumpbox/Makefile
@@ -1,0 +1,10 @@
+DOCKER_IMAGE   ?= huntprod/cf-jumpbox
+CONTAINER_NAME ?= jumpbox-16974f84-6f20-4f95-9aa4-5d2b30146cb9-flatten
+
+build:
+	docker build -t $(DOCKER_IMAGE):latest .
+
+push: build
+	docker push $(DOCKER_IMAGE):latest
+
+.PHONE: build push

--- a/manifests/jumpbox.yml
+++ b/manifests/jumpbox.yml
@@ -1,0 +1,37 @@
+name: jumpbox
+
+stemcells:
+  - alias:   default
+    os:      ubuntu-xenial
+    version: latest
+
+releases:
+  - name:    containers
+    version: latest
+
+update:
+  canaries:          1
+  max_in_flight:     1
+  serial:            true
+  canary_watch_time: 1000-120000
+  update_watch_time: 1000-120000
+
+instance_groups:
+  - name: docker
+    instances: 1 
+    azs: [z1]
+    vm_type: default
+    stemcell: default
+    networks:
+      - name: default
+    jobs:
+      - name: docker
+        release: containers
+
+      - name: jumpbox
+        release: containers
+        properties:
+          users:
+            - username: jhunt
+              key:      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKF3JPSfD1e92ryLKxYlSlXtDmbUUe0EOalBAJvthCmK jhunt@hydra.local
+              home:     /root


### PR DESCRIPTION
You can now configure the `jumpbox` job on an instance_group with a
`docker` job on it to colocate users with SSH keys.  When those users
SSH into the VM, they will be dumped into a docker container built
specifically for them, per their requirements (of tooling, OS, env,
etc.).

This should allow us to move past the need for something like
`jumpbox-boshrelease`, while providing more flexibility to jumpbox
users.