### PR TITLE
Use GitHub Actions for Release Engineering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
     name: Create BOSH Release
 
     steps:
-    - name:  git checkout
-      users: actions/checkout
+    - name: git checkout
+      uses: actions/checkout
 
     - name: bosh create-release
       id:   release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,6 @@ jobs:
     name: Create BOSH Release
     steps:
     - name: bosh create-release
-      uses: jhunt/bosh-create-release
+      uses: jhunt/bosh-create-release@v1
       with:
         version: 1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     name: Create BOSH Release
+
     steps:
+    - name:  git checkout
+      users: actions/checkout
+
     - name: bosh create-release
       id:   release
       uses: jhunt/bosh-create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branch: testing
 
 jobs:
-  hello_world_job:
+  create_release:
     runs-on: ubuntu-latest
     name: Create BOSH Release
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,65 @@
 ---
 on: 
   push:
-    branch: testing
+    tags: [ 'rc*' ]
 
 jobs:
-  create_release:
+  release:
+    name: Cut a Release
     runs-on: ubuntu-latest
-    name: Create BOSH Release
 
     steps:
-    - name: git checkout
-      uses: actions/checkout@v2
+      - name: git checkout
+        uses: actions/checkout@v2
 
-    - name: bosh create-release
-      id:   release
-      uses: jhunt/bosh-create-release@v1
-      with:
-        version: 1.2.3
+
+      - name: get version
+        id:   version
+        uses: frabert/replace-string-action@v1.1
+        with:
+          pattern:      '^refs.tags.build.*'
+          string:       ${{ github.ref }}
+          replace-with: '1.2.3'
+
+
+      - name: bosh create-release
+        id:   bosh
+        uses: jhunt/bosh-create-release@v1
+        with:
+          version: ${{ steps.version.outputs.replaced }}
+
+
+      - name: github release
+        id:   release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          tag_name:     ${{ github.ref }}
+          release_name: Blacksmith ${{ github.ref }}
+          draft:        false
+          prerelease:   false
+          body: |
+            _one of the core devs really ought to update these release notes..._
+
+
+      - name: upload bosh release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release.outputs.upload_url }}
+          asset_path: ${{ steps.bosh.outputs.tarball }}
+          asset_name: containers-${{ steps.version.outputs.replaced }}.tgz
+          asset_content_type: application/octet-stream
+
+
+      - name: git commit
+        uses: EndBug/add-and-commit@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          message: Release v${{ steps.version.outputs.replaced }}
+          tag:     v${{ steps.version.outputs.replaced }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+---
+on: 
+  push:
+    branch: testing
+
+jobs:
+  hello_world_job:
+    runs-on: ubuntu-latest
+    name: Create BOSH Release
+    steps:
+    - name: bosh create-release
+      uses: jhunt/bosh-create-release
+      with:
+        version: 1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     name: Create BOSH Release
     steps:
     - name: bosh create-release
+      id:   release
       uses: jhunt/bosh-create-release@v1
       with:
         version: 1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: git checkout
-      uses: actions/checkout
+      uses: actions/checkout@v2
 
     - name: bosh create-release
       id:   release

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ releases/**/*.tgz
 *~
 *#
 #*
+*.tgz


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow for cutting releases,
if you push to the rcX.Y.Z tag.