### PR TITLE
Update the used versions of Docker, Git and docker-compose

### DIFF
--- a/packages/docker/packaging
+++ b/packages/docker/packaging
@@ -3,20 +3,20 @@ set -eu
 
 CPUS=$(grep -c ^processor /proc/cpuinfo)
 
-# docker: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.0.tgz
-tar -xzf docker/docker-20.10.0.tgz
+# docker: https://download.docker.com/linux/static/stable/x86_64/docker-20.10.16.tgz
+tar -xzf docker/docker-20.10.16.tgz
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 cp docker/* ${BOSH_INSTALL_TARGET}/bin
 
-# git: https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.29.2.tar.gz
-tar -xzf docker/git-2.29.2.tar.gz
-pushd git-2.29.2 >/dev/null 2>&1
+# git: https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.36.1.tar.gz
+tar -xzf docker/git-2.36.1.tar.gz
+pushd git-2.36.1 >/dev/null 2>&1
 ./configure --prefix=${BOSH_INSTALL_TARGET}
 make -j$CPUS all
 make install
 popd >/dev/null 2>&1
 
-# docker-compose: https://github.com/docker/compose/releases/download/1.26.2/docker-compose-Linux-x86_64
+# docker-compose: https://github.com/docker/compose/releases/download/v2.5.1/docker-compose-linux-x86_64
 cp docker/docker-compose ${BOSH_INSTALL_TARGET}/bin/docker-compose-real
 cat >${BOSH_INSTALL_TARGET}/bin/docker-compose <<'EOF'
 #!/bin/sh

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -2,7 +2,7 @@
 name: docker
 dependencies: []
 files:
-  - docker/docker-20.10.0.tgz
-  - docker/git-2.29.2.tar.gz
+  - docker/docker-20.10.16.tgz
+  - docker/git-2.36.1.tar.gz
   - docker/docker-compose
   - ttar/ttar


### PR DESCRIPTION
Hi @jhunt,

as discussed [here](https://github.com/jhunt/containers-boshrelease/issues/14), I have prepared an appropriate PR and updated Docker, Git, docker-compose. 

Furthermore, I created a dev release on my side and consumed it accordingly in a CF dev landscape. 
FYI: In the process, we noticed that we could not consume the Docker and Jumpbox blobs (jobs) (not public available or no permissions) and had to clean up the release manifest directory accordingly for this.